### PR TITLE
More Visibility Options

### DIFF
--- a/gradescope_utils/autograder_utils/json_test_runner.py
+++ b/gradescope_utils/autograder_utils/json_test_runner.py
@@ -114,7 +114,7 @@ class JSONTestRunner(object):
     resultclass = JSONTestResult
 
     def __init__(self, stream=sys.stdout, descriptions=True, verbosity=1,
-                 failfast=False, buffer=True, visibility='visible',
+                 failfast=False, buffer=True, visibility=None,
                  stdout_visibility=None):
         """
         Set buffer to True to include test output in JSON

--- a/gradescope_utils/autograder_utils/json_test_runner.py
+++ b/gradescope_utils/autograder_utils/json_test_runner.py
@@ -114,7 +114,8 @@ class JSONTestRunner(object):
     resultclass = JSONTestResult
 
     def __init__(self, stream=sys.stdout, descriptions=True, verbosity=1,
-                 failfast=False, buffer=True, visibility='visible'):
+                 failfast=False, buffer=True, visibility='visible',
+                 stdout_visibility=None):
         """
         Set buffer to True to include test output in JSON
         """
@@ -126,7 +127,10 @@ class JSONTestRunner(object):
         self.json_data = {}
         self.json_data["tests"] = []
         self.json_data["leaderboard"] = []
-        self.json_data["visibility"] = visibility
+        if visibility:
+            self.json_data["visibility"] = visibility
+        if stdout_visibility:
+            self.json_data["stdout_visibility"] = stdout_visibility
 
     def _makeResult(self):
         return self.resultclass(self.stream, self.descriptions, self.verbosity,


### PR DESCRIPTION
This adds:
 - The ability to specify the `stdout_visibility` top-level key.
 - The ability to set `visibility=None` to get Gradescope's default behaviour (maybe this should be the default?).

Anything in particular I should do to test this?