### PR TITLE
Partial credit decorator

### DIFF
--- a/gradescope_utils/autograder_utils/decorators.py
+++ b/gradescope_utils/autograder_utils/decorators.py
@@ -90,13 +90,13 @@ class partial_credit(object):
     Usage: @partial_credit (no arguments)
 
     Then, within the test, set the value by calling
-    kwargs['set_points'] with a value. You can make this convenient by
-    explicitly declaring a set_points keyword argument, eg.
+    kwargs['set_score'] with a value. You can make this convenient by
+    explicitly declaring a set_score keyword argument, eg.
 
     ```
     @partial_credit
-    def test_partial(set_points=None):
-        set_points(42)
+    def test_partial(set_score=None):
+        set_score(42)
     ```
 
     """
@@ -106,8 +106,8 @@ class partial_credit(object):
         update_wrapper(self, func)
 
     def __call__(self, *args, **kwargs):
-        def set_points(x):
-            self.__points__ = x
+        def set_score(x):
+            self.__score__ = x
 
-        kwargs['set_points'] = set_points
+        kwargs['set_score'] = set_score
         return self.__func__(*args, **kwargs)

--- a/gradescope_utils/autograder_utils/decorators.py
+++ b/gradescope_utils/autograder_utils/decorators.py
@@ -1,4 +1,4 @@
-from functools import wraps, update_wrapper
+from functools import wraps
 
 
 class weight(object):

--- a/gradescope_utils/autograder_utils/decorators.py
+++ b/gradescope_utils/autograder_utils/decorators.py
@@ -1,4 +1,4 @@
-from functools import wraps
+from functools import wraps, update_wrapper
 
 
 class weight(object):
@@ -82,3 +82,32 @@ class leaderboard(object):
             return func(*args, **kwargs)
 
         return wrapper
+
+
+class partial_credit(object):
+    """Decorator that indicates that a test allows partial credit
+
+    Usage: @partial_credit (no arguments)
+
+    Then, within the test, set the value by calling
+    kwargs['set_points'] with a value. You can make this convenient by
+    explicitly declaring a set_points keyword argument, eg.
+
+    ```
+    @partial_credit
+    def test_partial(set_points=None):
+        set_points(42)
+    ```
+
+    """
+
+    def __init__(self, func):
+        self.__func__ = func
+        update_wrapper(self, func)
+
+    def __call__(self, *args, **kwargs):
+        def set_points(x):
+            self.__points__ = x
+
+        kwargs['set_points'] = set_points
+        return self.__func__(*args, **kwargs)

--- a/gradescope_utils/autograder_utils/decorators.py
+++ b/gradescope_utils/autograder_utils/decorators.py
@@ -87,27 +87,32 @@ class leaderboard(object):
 class partial_credit(object):
     """Decorator that indicates that a test allows partial credit
 
-    Usage: @partial_credit (no arguments)
+    Usage: @partial_credit(test_weight)
 
     Then, within the test, set the value by calling
     kwargs['set_score'] with a value. You can make this convenient by
     explicitly declaring a set_score keyword argument, eg.
 
     ```
-    @partial_credit
+    @partial_credit(10)
     def test_partial(set_score=None):
-        set_score(42)
+        set_score(4.2)
     ```
 
     """
 
-    def __init__(self, func):
-        self.__func__ = func
-        update_wrapper(self, func)
+    def __init__(self, weight):
+        self.weight = weight
 
-    def __call__(self, *args, **kwargs):
+    def __call__(self, func):
+        func.__weight__ = self.weight
+
         def set_score(x):
-            self.__score__ = x
+            wrapper.__score__ = x
 
-        kwargs['set_score'] = set_score
-        return self.__func__(*args, **kwargs)
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            kwargs['set_score'] = set_score
+            return func(*args, **kwargs)
+
+        return wrapper

--- a/gradescope_utils/autograder_utils/json_test_runner.py
+++ b/gradescope_utils/autograder_utils/json_test_runner.py
@@ -33,6 +33,9 @@ class JSONTestResult(result.TestResult):
     def getWeight(self, test):
         return getattr(getattr(test, test._testMethodName), '__weight__', 0.0)
 
+    def getScore(self, test):
+        return getattr(getattr(test, test._testMethodName), '__score__', None)
+
     def getVisibility(self, test):
         return getattr(getattr(test, test._testMethodName), '__visibility__', None)
 
@@ -61,13 +64,16 @@ class JSONTestResult(result.TestResult):
         weight = self.getWeight(test)
         tags = self.getTags(test)
         visibility = self.getVisibility(test)
+        score = self.getScore(test)
+        if score is None:
+            score = weight if passed else 0.0
 
         output = self.getOutput()
         if err:
             output += "Test Failed: {0}\n".format(err[1])
         result = {
             "name": self.getDescription(test),
-            "score": weight if passed else 0.0,
+            "score": score,
             "max_score": weight,
         }
         if tags:


### PR DESCRIPTION
Adds a `@partial_credit` decorator which can be used to assign partial credit to a test case. Provides a callback function `set_score` as a keyword argument to the test case, which can be used to set the score manually.

This should take precedence over the total/0 scoring from any asserts, but you have to call `set_score` before any failing assertions or else the test will exit before reaching `set_score`.