### PR TITLE
Instructors can override results (e.g. set late penalties) in a post-processor function

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -184,3 +184,6 @@ source_parsers = {
 }
 
 source_suffix = ['.rst', '.md']
+
+# Document constructors as well as class doc strings
+autoclass_content = 'both'

--- a/gradescope_utils/autograder_utils/json_test_runner.py
+++ b/gradescope_utils/autograder_utils/json_test_runner.py
@@ -181,7 +181,7 @@ class JSONTestRunner(object):
             total_score += test["score"]
         self.json_data["score"] = total_score
 
-        if self.post_processor:
+        if self.post_processor is not None:
             self.post_processor(self.json_data)
 
         json.dump(self.json_data, self.stream, indent=4)

--- a/gradescope_utils/autograder_utils/json_test_runner.py
+++ b/gradescope_utils/autograder_utils/json_test_runner.py
@@ -127,7 +127,7 @@ class JSONTestRunner(object):
 
     def __init__(self, stream=sys.stdout, descriptions=True, verbosity=1,
                  failfast=False, buffer=True, visibility=None,
-                 stdout_visibility=None):
+                 stdout_visibility=None, post_processor=None):
         """
         Set buffer to True to include test output in JSON
         """
@@ -136,6 +136,7 @@ class JSONTestRunner(object):
         self.verbosity = verbosity
         self.failfast = failfast
         self.buffer = buffer
+        self.post_processor = post_processor
         self.json_data = {}
         self.json_data["tests"] = []
         self.json_data["leaderboard"] = []
@@ -173,6 +174,9 @@ class JSONTestRunner(object):
         for test in self.json_data["tests"]:
             total_score += test["score"]
         self.json_data["score"] = total_score
+
+        if self.post_processor:
+            self.post_processor(self.json_data)
 
         json.dump(self.json_data, self.stream, indent=4)
         self.stream.write('\n')

--- a/gradescope_utils/autograder_utils/json_test_runner.py
+++ b/gradescope_utils/autograder_utils/json_test_runner.py
@@ -132,7 +132,7 @@ class JSONTestRunner(object):
         Set buffer to True to include test output in JSON
 
 
-        post_processor, if supplied, will be called with the final JSON
+        post_processor: if supplied, will be called with the final JSON
         data before it is written, allowing the caller to overwrite the
         test results (e.g. add a late penalty)
         """

--- a/gradescope_utils/autograder_utils/json_test_runner.py
+++ b/gradescope_utils/autograder_utils/json_test_runner.py
@@ -134,7 +134,8 @@ class JSONTestRunner(object):
 
         post_processor: if supplied, will be called with the final JSON
         data before it is written, allowing the caller to overwrite the
-        test results (e.g. add a late penalty)
+        test results (e.g. add a late penalty) by editing the results
+        dict in the first argument.
         """
         self.stream = stream
         self.descriptions = descriptions

--- a/gradescope_utils/autograder_utils/json_test_runner.py
+++ b/gradescope_utils/autograder_utils/json_test_runner.py
@@ -130,6 +130,11 @@ class JSONTestRunner(object):
                  stdout_visibility=None, post_processor=None):
         """
         Set buffer to True to include test output in JSON
+
+
+        post_processor, if supplied, will be called with the final JSON
+        data before it is written, allowing the caller to overwrite the
+        test results (e.g. add a late penalty)
         """
         self.stream = stream
         self.descriptions = descriptions


### PR DESCRIPTION
Adds a callback function to JSONTestRunner which can be used to modify the autograder results at the end of the test suite but before they are written to disk.

Usage Example:

```python
def post_process(results):
    results["score"] = 9001

if __name__ == '__main__':
    suite = unittest.defaultTestLoader.discover('tests')

    JSONTestRunner(visibility='visible', post_processor=post_process).run(suite)
```