### PR TITLE
Hide error messages

### DIFF
--- a/gradescope_utils/autograder_utils/decorators.py
+++ b/gradescope_utils/autograder_utils/decorators.py
@@ -51,10 +51,10 @@ class visibility(object):
         return func
 
 
-class hide_error(object):
-    """Simple decorator to add a __hide_error__ property to a function
+class hide_errors(object):
+    """Simple decorator to add a __hide_errors__ property to a function
 
-    Usage: @hide_error(True)
+    Usage: @hide_errors(True)
 
     Used to hide the particular source of an error which caused a test to fail.
     Otherwise, a test's particular assertions can be seen by students.
@@ -64,7 +64,7 @@ class hide_error(object):
         self.val = val
 
     def __call__(self, func):
-        func.__hide_error__ = self.val
+        func.__hide_errors__ = self.val
         return func
 
 

--- a/gradescope_utils/autograder_utils/decorators.py
+++ b/gradescope_utils/autograder_utils/decorators.py
@@ -51,6 +51,23 @@ class visibility(object):
         return func
 
 
+class hide_error(object):
+    """Simple decorator to add a __hide_error__ property to a function
+
+    Usage: @hide_error
+
+    Used to hide the particular source of an error which caused a test to fail.
+    Otherwise, a test's particular assertions can be seen by students.
+    """
+
+    def __init__(self):
+        self.val = True
+
+    def __call__(self, func):
+        func.__hide_error__ = self.val
+        return func
+
+
 class tags(object):
     """Simple decorator to add a __tags__ property to a function
 

--- a/gradescope_utils/autograder_utils/decorators.py
+++ b/gradescope_utils/autograder_utils/decorators.py
@@ -54,14 +54,14 @@ class visibility(object):
 class hide_error(object):
     """Simple decorator to add a __hide_error__ property to a function
 
-    Usage: @hide_error
+    Usage: @hide_error(True)
 
     Used to hide the particular source of an error which caused a test to fail.
     Otherwise, a test's particular assertions can be seen by students.
     """
 
-    def __init__(self):
-        self.val = True
+    def __init__(self, val):
+        self.val = val
 
     def __call__(self, func):
         func.__hide_error__ = self.val

--- a/gradescope_utils/autograder_utils/decorators.py
+++ b/gradescope_utils/autograder_utils/decorators.py
@@ -54,13 +54,13 @@ class visibility(object):
 class hide_errors(object):
     """Simple decorator to add a __hide_errors__ property to a function
 
-    Usage: @hide_errors(True)
+    Usage: @hide_errors("Error message to be shown upon test failure")
 
     Used to hide the particular source of an error which caused a test to fail.
     Otherwise, a test's particular assertions can be seen by students.
     """
 
-    def __init__(self, val):
+    def __init__(self, val="Test failed"):
         self.val = val
 
     def __call__(self, func):

--- a/gradescope_utils/autograder_utils/json_test_runner.py
+++ b/gradescope_utils/autograder_utils/json_test_runner.py
@@ -79,7 +79,7 @@ class JSONTestResult(result.TestResult):
         output = self.getOutput()
         if err:
             if hide_errors:
-                output += "Test Failed: Error Message Hidden\n"
+                output += "Test Failed.\n"
             else:
                 output += "Test Failed: {0}\n".format(err[1])
         result = {

--- a/gradescope_utils/autograder_utils/json_test_runner.py
+++ b/gradescope_utils/autograder_utils/json_test_runner.py
@@ -42,6 +42,9 @@ class JSONTestResult(result.TestResult):
     def getVisibility(self, test):
         return getattr(getattr(test, test._testMethodName), '__visibility__', None)
 
+    def getHideError(self, test):
+        return getattr(getattr(test, test._testMethodName), '__hide_error__', None)
+
     def getLeaderboardData(self, test):
         column_name = getattr(getattr(test, test._testMethodName), '__leaderboard_column__', None)
         sort_order = getattr(getattr(test, test._testMethodName), '__leaderboard_sort_order__', None)
@@ -68,13 +71,17 @@ class JSONTestResult(result.TestResult):
         tags = self.getTags(test)
         number = self.getNumber(test)
         visibility = self.getVisibility(test)
+        hide_error = self.getHideError(test)
         score = self.getScore(test)
         if score is None:
             score = weight if passed else 0.0
 
         output = self.getOutput()
         if err:
-            output += "Test Failed: {0}\n".format(err[1])
+            if hide_error:
+                output += "Test Failed: Error Hidden\n"
+            else:
+                output += "Test Failed: {0}\n".format(err[1])
         result = {
             "name": self.getDescription(test),
             "score": score,

--- a/gradescope_utils/autograder_utils/json_test_runner.py
+++ b/gradescope_utils/autograder_utils/json_test_runner.py
@@ -71,15 +71,15 @@ class JSONTestResult(result.TestResult):
         tags = self.getTags(test)
         number = self.getNumber(test)
         visibility = self.getVisibility(test)
-        hide_errors = self.getHideErrors(test)
+        hide_errors_message = self.getHideErrors(test)
         score = self.getScore(test)
         if score is None:
             score = weight if passed else 0.0
 
         output = self.getOutput()
         if err:
-            if hide_errors:
-                output += "Test Failed.\n"
+            if hide_errors_message:
+                output += hide_errors_message
             else:
                 output += "Test Failed: {0}\n".format(err[1])
         result = {

--- a/gradescope_utils/autograder_utils/json_test_runner.py
+++ b/gradescope_utils/autograder_utils/json_test_runner.py
@@ -42,8 +42,8 @@ class JSONTestResult(result.TestResult):
     def getVisibility(self, test):
         return getattr(getattr(test, test._testMethodName), '__visibility__', None)
 
-    def getHideError(self, test):
-        return getattr(getattr(test, test._testMethodName), '__hide_error__', None)
+    def getHideErrors(self, test):
+        return getattr(getattr(test, test._testMethodName), '__hide_errors__', None)
 
     def getLeaderboardData(self, test):
         column_name = getattr(getattr(test, test._testMethodName), '__leaderboard_column__', None)
@@ -71,15 +71,15 @@ class JSONTestResult(result.TestResult):
         tags = self.getTags(test)
         number = self.getNumber(test)
         visibility = self.getVisibility(test)
-        hide_error = self.getHideError(test)
+        hide_errors = self.getHideErrors(test)
         score = self.getScore(test)
         if score is None:
             score = weight if passed else 0.0
 
         output = self.getOutput()
         if err:
-            if hide_error:
-                output += "Test Failed: Error Hidden\n"
+            if hide_errors:
+                output += "Test Failed: Error Message Hidden\n"
             else:
                 output += "Test Failed: {0}\n".format(err[1])
         result = {


### PR DESCRIPTION
I've added a `@hide_errors(True)` decorator.

This can be used to hide the particular source of an error which caused a test to fail. Otherwise, a test's particular assertions can be seen by students.