### PR TITLE
Use "status" prop and other misc improvements

### DIFF
--- a/gradescope_utils/autograder_utils/json_test_runner.py
+++ b/gradescope_utils/autograder_utils/json_test_runner.py
@@ -83,7 +83,7 @@ class JSONTestResult(result.TestResult):
                         output += '\n'
                     else:
                         output += '\n\n'
-                output += f'FAIL: {err[1] or "<no msg>"}\n'
+                output += f'Fail: {err[1] or "<no msg>"}\n'
         result = {
             "name": self.getDescription(test),
         }

--- a/gradescope_utils/autograder_utils/json_test_runner.py
+++ b/gradescope_utils/autograder_utils/json_test_runner.py
@@ -85,7 +85,7 @@ class JSONTestResult(result.TestResult):
             if weight is None:
                 weight = 0.0
             if score is None:
-                score = 0.0 if err else weight
+                score = 0.0 if failed else weight
             result["score"] = score
             result["max_score"] = weight
              # Also mark failure if points are lost
@@ -191,7 +191,7 @@ class JSONTestRunner(object):
 
         total_score = 0
         for test in self.json_data["tests"]:
-            total_score += test["score"]
+            total_score += test.get("score", 0.0)
         self.json_data["score"] = total_score
 
         if self.post_processor is not None:

--- a/gradescope_utils/autograder_utils/json_test_runner.py
+++ b/gradescope_utils/autograder_utils/json_test_runner.py
@@ -83,7 +83,7 @@ class JSONTestResult(result.TestResult):
                         output += '\n'
                     else:
                         output += '\n\n'
-                output += f'Fail: {err[1] or "<no msg>"}\n'
+                output += "Test Failed: {0}\n".format(err[1])
         result = {
             "name": self.getDescription(test),
         }

--- a/gradescope_utils/autograder_utils/json_test_runner.py
+++ b/gradescope_utils/autograder_utils/json_test_runner.py
@@ -65,6 +65,7 @@ class JSONTestResult(result.TestResult):
             return out
 
     def buildResult(self, test, err=None):
+        failed = err is not None
         weight = self.getWeight(test)
         tags = self.getTags(test)
         number = self.getNumber(test)
@@ -79,7 +80,6 @@ class JSONTestResult(result.TestResult):
                 output += err[1] + '\n' if err[1] else 'Test Failed\n'
         result = {
             "name": self.getDescription(test),
-            "status": "failed" if err else "passed",
         }
         if score is not None or weight is not None:
             if weight is None:
@@ -88,6 +88,11 @@ class JSONTestResult(result.TestResult):
                 score = 0.0 if err else weight
             result["score"] = score
             result["max_score"] = weight
+             # Also mark failure if points are lost
+            failed |= score < weight
+
+        result["status"] = "failed" if failed else "passed"
+
         if tags:
             result["tags"] = tags
         if output:

--- a/gradescope_utils/autograder_utils/json_test_runner.py
+++ b/gradescope_utils/autograder_utils/json_test_runner.py
@@ -77,7 +77,7 @@ class JSONTestResult(result.TestResult):
             if hide_errors_message:
                 output += hide_errors_message
             else:
-                output += err[1] + '\n' if err[1] else 'Test Failed\n'
+                output += f'{err[1]}\n' if err[1] else 'Test Failed\n'
         result = {
             "name": self.getDescription(test),
         }

--- a/gradescope_utils/autograder_utils/json_test_runner.py
+++ b/gradescope_utils/autograder_utils/json_test_runner.py
@@ -72,17 +72,16 @@ class JSONTestResult(result.TestResult):
         visibility = self.getVisibility(test)
         hide_errors_message = self.getHideErrors(test)
         score = self.getScore(test)
-        output = self.getOutput()
+        output = self.getOutput() or ""
         if err:
             if hide_errors_message:
                 output += hide_errors_message
             else:
-                if output:
-                    # create a double newline
-                    if output.endswith('\n'):
-                        output += '\n'
-                    else:
-                        output += '\n\n'
+                # create a double newline
+                if output.endswith('\n'):
+                    output += '\n'
+                else:
+                    output += '\n\n'
                 output += "Test Failed: {0}\n".format(err[1])
         result = {
             "name": self.getDescription(test),

--- a/gradescope_utils/autograder_utils/json_test_runner.py
+++ b/gradescope_utils/autograder_utils/json_test_runner.py
@@ -77,7 +77,13 @@ class JSONTestResult(result.TestResult):
             if hide_errors_message:
                 output += hide_errors_message
             else:
-                output += f'\nFAIL: {err[1] or "<no msg>"}\n'
+                if output:
+                    # create a double newline
+                    if output.endswith('\n'):
+                        output += '\n'
+                    else:
+                        output += '\n\n'
+                output += f'FAIL: {err[1] or "<no msg>"}\n'
         result = {
             "name": self.getDescription(test),
         }

--- a/gradescope_utils/autograder_utils/json_test_runner.py
+++ b/gradescope_utils/autograder_utils/json_test_runner.py
@@ -77,7 +77,7 @@ class JSONTestResult(result.TestResult):
             if hide_errors_message:
                 output += hide_errors_message
             else:
-                output += f'FAIL: {err[1] or "<no msg>"}\n'
+                output += f'\nFAIL: {err[1] or "<no msg>"}\n'
         result = {
             "name": self.getDescription(test),
         }

--- a/gradescope_utils/autograder_utils/json_test_runner.py
+++ b/gradescope_utils/autograder_utils/json_test_runner.py
@@ -77,7 +77,7 @@ class JSONTestResult(result.TestResult):
             if hide_errors_message:
                 output += hide_errors_message
             else:
-                output += f'{err[1]}\n' if err[1] else 'Test Failed\n'
+                output += f'FAIL: {err[1] or "<no msg>"}\n'
         result = {
             "name": self.getDescription(test),
         }

--- a/gradescope_utils/autograder_utils/json_test_runner.py
+++ b/gradescope_utils/autograder_utils/json_test_runner.py
@@ -77,11 +77,12 @@ class JSONTestResult(result.TestResult):
             if hide_errors_message:
                 output += hide_errors_message
             else:
-                # create a double newline
-                if output.endswith('\n'):
-                    output += '\n'
-                else:
-                    output += '\n\n'
+                if output:
+                    # Create a double newline if output is not empty
+                    if output.endswith('\n'):
+                        output += '\n'
+                    else:
+                        output += '\n\n'
                 output += "Test Failed: {0}\n".format(err[1])
         result = {
             "name": self.getDescription(test),


### PR DESCRIPTION
Use new ["status"](https://gradescope-autograders.readthedocs.io/en/latest/specs/#test-case-status) key to mark failing tests red, even if they are 0 weight.