### PR TITLE
Fix setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ setup(
 
     description='Utilities for building Gradescope autograders',
     long_description=long_description,
+    long_description_content_type='text/markdown',
 
     # The project's main homepage.
     url='https://github.com/gradescope/gradescope-utils',


### PR DESCRIPTION
Set long_description_content_type to markdown.

Fixes this publish issue which was preventing this from being published to TestPyPI (and presumably PyPI). https://github.com/gradescope/gradescope-utils/actions/runs/3183742123/jobs/5191326130#step:6:14

Screenshot from TestPyPI (https://test.pypi.org/manage/project/gradescope-utils/releases/):
![image](https://user-images.githubusercontent.com/47774/196274852-7aa6b839-5143-49f3-8445-3a9da3c4e817.png)

Successful publish https://github.com/gradescope/gradescope-utils/actions/runs/3268276182/jobs/5374499935#step:6:16