### PR TITLE
Enable Gradescope and Django Integration

### DIFF
--- a/gradescope_utils/autograder_utils/GradescopeRunner.py
+++ b/gradescope_utils/autograder_utils/GradescopeRunner.py
@@ -1,0 +1,18 @@
+import sys
+from django.test.runner import DiscoverRunner
+from gradescope_utils.autograder_utils.json_test_runner import JSONTestRunner
+
+
+class GradescopeRunner(DiscoverRunner):
+    """Replacing Django Default Unit Test Runner with Gradescope Test Runner"""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    def run_suite(self, suite, **kwargs):
+        return JSONTestRunner(
+            stream=sys.stdout, descriptions=True, verbosity=1,
+            failfast=False, buffer=True, visibility="visible",
+            stdout_visibility=None, post_processor=None,
+            failure_prefix="Test Failed: "
+        ).run(suite)

--- a/gradescope_utils/autograder_utils/README.md
+++ b/gradescope_utils/autograder_utils/README.md
@@ -80,3 +80,18 @@ Example output:
     ]
 }
 ```
+
+### GradescopeRunner
+This allows for an integration between Django testing, which utilizes unittest and 
+Gradescope's JSONTestRunner to obtain the JSON output of the Django test cases. 
+To enable this, complete the following steps:  
+
+First, in your settings.py, insert the line:
+```
+`TEST_RUNNER = 'gradescope_utils.autograder_utils.GradescopeRunner.GradescopeRunner'`
+```
+
+Then, within your `run_autograder`, run the following command:
+```
+python3 manage.py test -v 0 > /autograder/results/results.json
+```


### PR DESCRIPTION
Hello,
This code would allow for Gradescope to auto-grade assignments in a Django environment. Within my class, students are expected to repair a buggy Django implementation, and I have grading scripts to verify the bugs are remediated. However, to enable an integration with Gradescope, I had to tweak the default Django DiscoverRunner class to be able to output the JSON file required by Gradescope. The README is updated, describing the steps to complete the integration.