### PR TITLE
Figured out how to pass parameters from settings

### DIFF
--- a/gradescope_utils/autograder_utils/README.md
+++ b/gradescope_utils/autograder_utils/README.md
@@ -86,10 +86,23 @@ This allows for an integration between Django testing, which utilizes unittest a
 Gradescope's JSONTestRunner to obtain the JSON output of the Django test cases. 
 To enable this, complete the following steps:  
 
-First, in your settings.py, insert the line:
+First, in your settings.py, insert the lines:
 ```
-`TEST_RUNNER = 'gradescope_utils.autograder_utils.gradescope_django_runner.GradescopeDjangoRunner'`
+TEST_RUNNER = 'gradescope_utils.autograder_utils.gradescope_django_runner.GradescopeDjangoRunner'
+
+gradescope_parameters = {
+    'stream': sys.stdout,
+    'descriptions': True,
+    'verbosity': 1,
+    'failfast': False,
+    'buffer': True,
+    'visibility': "visible",
+    'stdout_visibility': None,
+    'post_processor': None,
+    'failure_prefix': "Test Failed: "
+}
 ```
+The `gradescope_parameters` is used to set arguments for the JSONTestRunner.
 
 Then, within your `run_autograder`, run the following command:
 ```

--- a/gradescope_utils/autograder_utils/README.md
+++ b/gradescope_utils/autograder_utils/README.md
@@ -82,11 +82,12 @@ Example output:
 ```
 
 ### GradescopeDjangoRunner
-This allows for an integration between Django testing, which utilizes unittest and 
-Gradescope's JSONTestRunner to obtain the JSON output of the Django test cases. 
+This allows for an integration between Django testing, which utilizes unittest and Gradescope's JSONTestRunner to obtain the JSON output of the Django test cases. 
+
 To enable this, complete the following steps:  
 
-First, in your settings.py, insert the lines:
+The `GRADESCOPE_PARAMETERS` is used to set different arguments for the JSONTestRunner from the default ones:
+In your settings.py, insert the lines below: 
 ```python
 TEST_RUNNER = 'gradescope_utils.autograder_utils.gradescope_django_runner.GradescopeDjangoRunner'
 
@@ -102,7 +103,6 @@ GRADESCOPE_PARAMETERS = {
     'failure_prefix': "Test Failed: "
 }
 ```
-The `gradescope_parameters` is used to set arguments for the JSONTestRunner.
 
 Then, within your `run_autograder`, run the following command:
 ```

--- a/gradescope_utils/autograder_utils/README.md
+++ b/gradescope_utils/autograder_utils/README.md
@@ -87,10 +87,10 @@ Gradescope's JSONTestRunner to obtain the JSON output of the Django test cases.
 To enable this, complete the following steps:  
 
 First, in your settings.py, insert the lines:
-```
+```python
 TEST_RUNNER = 'gradescope_utils.autograder_utils.gradescope_django_runner.GradescopeDjangoRunner'
 
-gradescope_parameters = {
+GRADESCOPE_PARAMETERS = {
     'stream': sys.stdout,
     'descriptions': True,
     'verbosity': 1,

--- a/gradescope_utils/autograder_utils/README.md
+++ b/gradescope_utils/autograder_utils/README.md
@@ -86,8 +86,7 @@ This allows for an integration between Django testing, which utilizes unittest a
 
 To enable this, complete the following steps:  
 
-The `GRADESCOPE_PARAMETERS` is used to set different arguments for the JSONTestRunner from the default ones:
-In your settings.py, insert the lines below: 
+1. The `GRADESCOPE_PARAMETERS` is used to set different arguments for the JSONTestRunner from the default ones. In your settings.py, insert the lines below: 
 ```python
 TEST_RUNNER = 'gradescope_utils.autograder_utils.gradescope_django_runner.GradescopeDjangoRunner'
 
@@ -104,7 +103,7 @@ GRADESCOPE_PARAMETERS = {
 }
 ```
 
-Then, within your `run_autograder`, run the following command:
+2. You can either pass a file descriptor to `/autograder/results/results.json` as an argument to `'stream'` in the `GRADESCOPE_PARAMETERS`. Alternatively, within your `run_autograder`, run the following command:
 ```
 python3 manage.py test -v 0 > /autograder/results/results.json
 ```

--- a/gradescope_utils/autograder_utils/README.md
+++ b/gradescope_utils/autograder_utils/README.md
@@ -86,8 +86,10 @@ This allows for an integration between Django testing, which utilizes unittest a
 
 To enable this, complete the following steps:  
 
-1. The `GRADESCOPE_PARAMETERS` is used to set different arguments for the JSONTestRunner from the default ones. In your settings.py, insert the lines below: 
+* The `GRADESCOPE_PARAMETERS` is used to set different arguments for the JSONTestRunner from the default ones. In your settings.py, insert the lines below: 
 ```python
+import sys
+
 TEST_RUNNER = 'gradescope_utils.autograder_utils.gradescope_django_runner.GradescopeDjangoRunner'
 
 GRADESCOPE_PARAMETERS = {
@@ -103,7 +105,7 @@ GRADESCOPE_PARAMETERS = {
 }
 ```
 
-2. You can either pass a file descriptor to `/autograder/results/results.json` as an argument to `'stream'` in the `GRADESCOPE_PARAMETERS`. Alternatively, within your `run_autograder`, run the following command:
+* You can either pass a file descriptor to `/autograder/results/results.json` as an argument to `'stream'` in the `GRADESCOPE_PARAMETERS`. Alternatively, within your `run_autograder`, run the following command:
 ```
 python3 manage.py test -v 0 > /autograder/results/results.json
 ```

--- a/gradescope_utils/autograder_utils/gradescope_django_runner.py
+++ b/gradescope_utils/autograder_utils/gradescope_django_runner.py
@@ -1,6 +1,7 @@
 import sys
-from django.test.runner import DiscoverRunner
 from gradescope_utils.autograder_utils.json_test_runner import JSONTestRunner
+from django.test.runner import DiscoverRunner
+from django.conf import settings
 
 
 class GradescopeDjangoRunner(DiscoverRunner):
@@ -8,6 +9,12 @@ class GradescopeDjangoRunner(DiscoverRunner):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+        self.test_runner = JSONTestRunner
 
-    def run_suite(self, suite, **kwargs):
-        return JSONTestRunner(**kwargs).run(suite)
+    def get_gradescope_runner_kwargs(self):
+        return getattr(settings, "gradescope_parameters", {})
+
+    def run_suite(self, suite):
+        kwargs = self.get_test_runner_kwargs()
+        runner = self.test_runner(**kwargs)
+        return runner.run(suite)

--- a/gradescope_utils/autograder_utils/gradescope_django_runner.py
+++ b/gradescope_utils/autograder_utils/gradescope_django_runner.py
@@ -8,8 +8,8 @@ class GradescopeDjangoRunner(DiscoverRunner):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        kwargs = getattr(settings, "GRADESCOPE_PARAMETERS", {})
-        self.test_runner = JSONTestRunner(**kwargs)
+        parameters = getattr(settings, "GRADESCOPE_PARAMETERS", {})
+        self.test_runner = JSONTestRunner(**parameters)
 
     def run_suite(self, suite, **kwargs):
         return self.test_runner.run(suite)

--- a/gradescope_utils/autograder_utils/gradescope_django_runner.py
+++ b/gradescope_utils/autograder_utils/gradescope_django_runner.py
@@ -1,4 +1,3 @@
-import sys
 from gradescope_utils.autograder_utils.json_test_runner import JSONTestRunner
 from django.test.runner import DiscoverRunner
 from django.conf import settings
@@ -9,13 +8,8 @@ class GradescopeDjangoRunner(DiscoverRunner):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.test_runner = None
-
-    def get_gradescope_runner_kwargs(self):
-        return getattr(settings, "GRADESCOPE_PARAMETERS", {})
-
-    def run_suite(self, suite):
-        kwargs = self.get_gradescope_runner_kwargs()
+        kwargs = getattr(settings, "GRADESCOPE_PARAMETERS", {})
         self.test_runner = JSONTestRunner(**kwargs)
-        return self.test_runner.run(suite)
 
+    def run_suite(self, suite, **kwargs):
+        return self.test_runner.run(suite)

--- a/gradescope_utils/autograder_utils/gradescope_django_runner.py
+++ b/gradescope_utils/autograder_utils/gradescope_django_runner.py
@@ -9,12 +9,13 @@ class GradescopeDjangoRunner(DiscoverRunner):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.test_runner = JSONTestRunner
+        self.test_runner = None
 
     def get_gradescope_runner_kwargs(self):
-        return getattr(settings, "gradescope_parameters", {})
+        return getattr(settings, "GRADESCOPE_PARAMETERS", {})
 
     def run_suite(self, suite):
-        kwargs = self.get_test_runner_kwargs()
-        runner = self.test_runner(**kwargs)
-        return runner.run(suite)
+        kwargs = self.get_gradescope_runner_kwargs()
+        self.test_runner = JSONTestRunner(**kwargs)
+        return self.test_runner.run(suite)
+


### PR DESCRIPTION
Hello,
I figured out how to pass parameters to the JSONTestRunner from settings.py file in Django. I was able to test it locally with no issues.

I am wondering, when would anyone else be able to download these updates? Furthermore, I figure this could be useful for anyone teaching courses on either developing Django applications or in my case, use a buggy Django implementation for a CTF.