### PR TITLE
Reconfigured subtest handling

### DIFF
--- a/gradescope_utils/autograder_utils/decorators.py
+++ b/gradescope_utils/autograder_utils/decorators.py
@@ -154,11 +154,11 @@ class partial_credit(object):
 class merge_subtests(object):
     """Decorator that merges subtests into a single test case
     
-    Usage: @merge_subtests('True')
+    Usage: @merge_subtests(True)
     """
 
     def __init__(self, val):
-        self.val = str(val)
+        self.val = val
 
     def __call__(self, func):
         func.__merge_subtests__ = self.val

--- a/gradescope_utils/autograder_utils/decorators.py
+++ b/gradescope_utils/autograder_utils/decorators.py
@@ -149,3 +149,17 @@ class partial_credit(object):
             return func(*args, **kwargs)
 
         return wrapper
+
+
+class merge_subtests(object):
+    """Decorator that merges subtests into a single test case
+    
+    Usage: @merge_subtests(True)
+    """
+
+    def __init__(self, val):
+        self.val = val
+
+    def __call__(self, func):
+        func.__merge_subtests__ = self.val
+        return func

--- a/gradescope_utils/autograder_utils/decorators.py
+++ b/gradescope_utils/autograder_utils/decorators.py
@@ -154,11 +154,11 @@ class partial_credit(object):
 class merge_subtests(object):
     """Decorator that merges subtests into a single test case
     
-    Usage: @merge_subtests(True)
+    Usage: @merge_subtests('True')
     """
 
     def __init__(self, val):
-        self.val = val
+        self.val = str(val)
 
     def __call__(self, func):
         func.__merge_subtests__ = self.val

--- a/gradescope_utils/autograder_utils/json_test_runner.py
+++ b/gradescope_utils/autograder_utils/json_test_runner.py
@@ -241,13 +241,13 @@ class JSONTestRunner(object):
             merged_dict = {}
 
             for test in self.json_data["tests"]:
-                if test["merge_subtests"]:
-                    if test["name"] in merged_dict:
+                try: 
+                    if test["name"] in merged_dict and test["merge_subtests"]:
                         merged_dict[test["name"]]["output"] += test["output"]
                     else:
                         merged_dict[test["name"]] = test
                 
-                else:
+                except KeyError:
                     merged_dict[test["name"]] = test
                 
             self.json_data["tests"] = list(merged_dict.values())

--- a/gradescope_utils/autograder_utils/json_test_runner.py
+++ b/gradescope_utils/autograder_utils/json_test_runner.py
@@ -254,6 +254,8 @@ class JSONTestRunner(object):
                 except KeyError:
                     list_of_tests.append(test)
 
+            self.json_data["tests"] = list_of_tests
+
         json.dump(self.json_data, self.stream, indent=4)
         self.stream.write('\n')
 

--- a/gradescope_utils/autograder_utils/json_test_runner.py
+++ b/gradescope_utils/autograder_utils/json_test_runner.py
@@ -238,34 +238,26 @@ class JSONTestRunner(object):
             self.post_processor(self.json_data)
 
         if self._checkMergeSubtests(self.json_data["tests"], "merge_subtests"):
-            list_of_tests = []
 
-            print(1)
-            
-            for test in self.json_data["tests"]:
-                print(2)
-                try:
-                    print(3)
-                    if test["merge_subtests"]:
-                        print(4)
-                        for dict in list_of_tests:
-                            print(5)
-                            if test["name"] in dict:
-                                print(6)
-                                dict[test["name"]]["output"] += test["output"]
-                            else:
-                                print(7)
-                                list_of_tests.append(test)               
-                    else:
-                        print(8)
-                        list_of_tests.append(test)
+            try:
+                if len(self.json_data["tests"]) > 1:
 
-                except KeyError:
-                    print(9)
-                    list_of_tests.append(test)
-            print(10)
-            self.json_data["tests"] = list_of_tests
-        print(11)
+                    i = 0
+                    while i < len(self.json_data["tests"]):
+                        
+                        if (self.json_data["tests"][i]["name"] == self.json_data["tests"][i+1]["name"]
+                            and self.json_data["tests"][i]["merge_subtests"] == 'True'):
+                            self.json_data["tests"][i]["output"] += self.json_data["tests"][i+1]["output"]
+                            del self.json_data["tests"][i+1]
+
+                        else:
+                            i += 1
+                            if i + 1 >= len(self.json_data["tests"]):
+                                break
+
+            except KeyError:
+                pass
+
         json.dump(self.json_data, self.stream, indent=4)
         self.stream.write('\n')
 

--- a/gradescope_utils/autograder_utils/json_test_runner.py
+++ b/gradescope_utils/autograder_utils/json_test_runner.py
@@ -238,19 +238,17 @@ class JSONTestRunner(object):
             self.post_processor(self.json_data)
 
         if self._checkMergeSubtests(self.json_data["tests"], "merge_subtests"):
-            merged_dict = {}
-
+            list_of_tests = []
+            
             for test in self.json_data["tests"]:
                 if test["merge_subtests"]:
-                    if test["name"] in merged_dict:
-                        merged_dict[test["name"]]["output"] += test["output"]
-                    else:
-                        merged_dict[test["name"]] = test
-                
+                    for dict in list_of_tests:
+                        if test["name"] in dict:
+                            dict[test["name"]]["output"] += test["output"]
+                        else:
+                            list_of_tests.append(test)               
                 else:
-                    merged_dict[test["name"]] = test
-                
-            self.json_data["tests"] = list(merged_dict.values())
+                    list_of_tests.append(test)
 
         json.dump(self.json_data, self.stream, indent=4)
         self.stream.write('\n')

--- a/gradescope_utils/autograder_utils/json_test_runner.py
+++ b/gradescope_utils/autograder_utils/json_test_runner.py
@@ -246,7 +246,7 @@ class JSONTestRunner(object):
                     while i < len(self.json_data["tests"]):
                         
                         if (self.json_data["tests"][i]["name"] == self.json_data["tests"][i+1]["name"]
-                            and self.json_data["tests"][i]["merge_subtests"] == 'True'):
+                            and self.json_data["tests"][i]["merge_subtests"]):
                             self.json_data["tests"][i]["output"] += self.json_data["tests"][i+1]["output"]
                             del self.json_data["tests"][i+1]
 

--- a/gradescope_utils/autograder_utils/json_test_runner.py
+++ b/gradescope_utils/autograder_utils/json_test_runner.py
@@ -200,6 +200,13 @@ class JSONTestRunner(object):
         return self.resultclass(self.stream, self.descriptions, self.verbosity,
                                 self.json_data["tests"], self.json_data["leaderboard"],
                                 self.failure_prefix)
+    
+    def _checkMergeSubtests(self, list_of_dicts, key):
+        "Check if subtests should be merged."
+        for dict in list_of_dicts:
+            if key in dict:
+                return True
+        return False
 
     def run(self, test):
         "Run the given test case or test suite."
@@ -230,14 +237,14 @@ class JSONTestRunner(object):
         if self.post_processor is not None:
             self.post_processor(self.json_data)
 
-        try:
-            if len(self.json_data["tests"]) > 1:
-
-                i = 0
-                while i < len(self.json_data["tests"]):
-                    
+        if self._checkMergeSubtests(self.json_data["tests"], "merge_subtests"):
+            
+            i = 0
+            while i < len(self.json_data["tests"]):
+                
+                try:
                     if (self.json_data["tests"][i]["name"] == self.json_data["tests"][i+1]["name"]
-                        and self.json_data["tests"][i]["merge_subtests"] == True):
+                        and self.json_data["tests"][i]["merge_subtests"]):
                         self.json_data["tests"][i]["output"] += self.json_data["tests"][i+1]["output"]
                         del self.json_data["tests"][i+1]
 
@@ -245,9 +252,11 @@ class JSONTestRunner(object):
                         i += 1
                         if i + 1 >= len(self.json_data["tests"]):
                             break
-
-        except KeyError:
-            pass
+                
+                except KeyError:
+                    i += 1
+                    if i + 1 >= len(self.json_data["tests"]):
+                        break
 
         json.dump(self.json_data, self.stream, indent=4)
         self.stream.write('\n')

--- a/gradescope_utils/autograder_utils/json_test_runner.py
+++ b/gradescope_utils/autograder_utils/json_test_runner.py
@@ -239,23 +239,33 @@ class JSONTestRunner(object):
 
         if self._checkMergeSubtests(self.json_data["tests"], "merge_subtests"):
             list_of_tests = []
+
+            print(1)
             
             for test in self.json_data["tests"]:
+                print(2)
                 try:
+                    print(3)
                     if test["merge_subtests"]:
+                        print(4)
                         for dict in list_of_tests:
+                            print(5)
                             if test["name"] in dict:
+                                print(6)
                                 dict[test["name"]]["output"] += test["output"]
                             else:
+                                print(7)
                                 list_of_tests.append(test)               
                     else:
+                        print(8)
                         list_of_tests.append(test)
 
                 except KeyError:
+                    print(9)
                     list_of_tests.append(test)
-
+            print(10)
             self.json_data["tests"] = list_of_tests
-
+        print(11)
         json.dump(self.json_data, self.stream, indent=4)
         self.stream.write('\n')
 

--- a/gradescope_utils/autograder_utils/json_test_runner.py
+++ b/gradescope_utils/autograder_utils/json_test_runner.py
@@ -238,19 +238,15 @@ class JSONTestRunner(object):
             self.post_processor(self.json_data)
 
         if self._checkMergeSubtests(self.json_data["tests"], "merge_subtests"):
-            merged_dict = {}
 
             for test in self.json_data["tests"]:
                 try: 
-                    if test["name"] in merged_dict and test["merge_subtests"]:
-                        merged_dict[test["name"]]["output"] += test["output"]
-                    else:
-                        merged_dict[test["name"]] = test
+                    if test["merge_subtests"]:
+                        self.json_data[test["name"]]["output"] += test["output"]
+                        del test
                 
                 except KeyError:
-                    merged_dict[test["name"]] = test
-                
-            self.json_data["tests"] = list(merged_dict.values())
+                    pass
 
         json.dump(self.json_data, self.stream, indent=4)
         self.stream.write('\n')

--- a/gradescope_utils/autograder_utils/json_test_runner.py
+++ b/gradescope_utils/autograder_utils/json_test_runner.py
@@ -200,13 +200,6 @@ class JSONTestRunner(object):
         return self.resultclass(self.stream, self.descriptions, self.verbosity,
                                 self.json_data["tests"], self.json_data["leaderboard"],
                                 self.failure_prefix)
-    
-    def _checkMergeSubtests(self, list_of_dicts, key):
-        "Check if subtests should be merged."
-        for dict in list_of_dicts:
-            if key in dict:
-                return True
-        return False
 
     def run(self, test):
         "Run the given test case or test suite."
@@ -244,7 +237,7 @@ class JSONTestRunner(object):
                 while i < len(self.json_data["tests"]):
                     
                     if (self.json_data["tests"][i]["name"] == self.json_data["tests"][i+1]["name"]
-                        and self.json_data["tests"][i]["merge_subtests"]):
+                        and self.json_data["tests"][i]["merge_subtests"] == True):
                         self.json_data["tests"][i]["output"] += self.json_data["tests"][i+1]["output"]
                         del self.json_data["tests"][i+1]
 

--- a/gradescope_utils/autograder_utils/json_test_runner.py
+++ b/gradescope_utils/autograder_utils/json_test_runner.py
@@ -237,26 +237,24 @@ class JSONTestRunner(object):
         if self.post_processor is not None:
             self.post_processor(self.json_data)
 
-        if self._checkMergeSubtests(self.json_data["tests"], "merge_subtests"):
+        try:
+            if len(self.json_data["tests"]) > 1:
 
-            try:
-                if len(self.json_data["tests"]) > 1:
+                i = 0
+                while i < len(self.json_data["tests"]):
+                    
+                    if (self.json_data["tests"][i]["name"] == self.json_data["tests"][i+1]["name"]
+                        and self.json_data["tests"][i]["merge_subtests"]):
+                        self.json_data["tests"][i]["output"] += self.json_data["tests"][i+1]["output"]
+                        del self.json_data["tests"][i+1]
 
-                    i = 0
-                    while i < len(self.json_data["tests"]):
-                        
-                        if (self.json_data["tests"][i]["name"] == self.json_data["tests"][i+1]["name"]
-                            and self.json_data["tests"][i]["merge_subtests"]):
-                            self.json_data["tests"][i]["output"] += self.json_data["tests"][i+1]["output"]
-                            del self.json_data["tests"][i+1]
+                    else:
+                        i += 1
+                        if i + 1 >= len(self.json_data["tests"]):
+                            break
 
-                        else:
-                            i += 1
-                            if i + 1 >= len(self.json_data["tests"]):
-                                break
-
-            except KeyError:
-                pass
+        except KeyError:
+            pass
 
         json.dump(self.json_data, self.stream, indent=4)
         self.stream.write('\n')

--- a/gradescope_utils/autograder_utils/json_test_runner.py
+++ b/gradescope_utils/autograder_utils/json_test_runner.py
@@ -226,6 +226,10 @@ class JSONTestRunner(object):
         if self.post_processor is not None:
             self.post_processor(self.json_data)
 
+
+        json.dump(self.json_data, self.stream, indent=4)
+        self.stream.write('\n')
+        
         if len(self.json_data["tests"]) > 1:
             i = 0
             while i < len(self.json_data["tests"]):
@@ -238,6 +242,5 @@ class JSONTestRunner(object):
                     if i + 1 >= len(self.json_data["tests"]):
                         break
             
-        json.dump(self.json_data, self.stream, indent=4)
-        self.stream.write('\n')
+
         return result

--- a/gradescope_utils/autograder_utils/json_test_runner.py
+++ b/gradescope_utils/autograder_utils/json_test_runner.py
@@ -144,9 +144,9 @@ class JSONTestResult(result.TestResult):
         if outcome == None:
             pass
         else:
-            super(JSONTestResult, self).addFailure(subtest, outcome)
+            super(JSONTestResult, self).addFailure(test, outcome)
             self._mirrorOutput = False
-            self.processResult(subtest, outcome)
+            self.processResult(test, outcome)
 
 
 class JSONTestRunner(object):

--- a/gradescope_utils/autograder_utils/json_test_runner.py
+++ b/gradescope_utils/autograder_utils/json_test_runner.py
@@ -78,6 +78,7 @@ class JSONTestResult(result.TestResult):
         hide_errors_message = self.getHideErrors(test)
         score = self.getScore(test)
         output = self.getOutput() or ""
+        merge_subtests = self.getMergeSubtests(test)
 
         if err:
             if hide_errors_message:
@@ -113,6 +114,8 @@ class JSONTestResult(result.TestResult):
             result["visibility"] = visibility
         if number:
             result["number"] = number
+        if merge_subtests:
+            result["merge_subtests"] = merge_subtests
         return result
 
     def buildLeaderboardEntry(self, test):

--- a/gradescope_utils/autograder_utils/json_test_runner.py
+++ b/gradescope_utils/autograder_utils/json_test_runner.py
@@ -165,7 +165,7 @@ class JSONTestRunner(object):
                  failfast=False, buffer=True, visibility=None,
                  stdout_visibility=None, post_processor=None,
                  failure_prefix="Test Failed: ",
-                 merge_subtests=False):
+                 merge_subtests=True):
         """
         Set buffer to True to include test output in JSON
 

--- a/gradescope_utils/autograder_utils/json_test_runner.py
+++ b/gradescope_utils/autograder_utils/json_test_runner.py
@@ -114,8 +114,7 @@ class JSONTestResult(result.TestResult):
             result["visibility"] = visibility
         if number:
             result["number"] = number
-        if merge_subtests:
-            result["merge_subtests"] = merge_subtests
+        result["merge_subtests"] = merge_subtests
         return result
 
     def buildLeaderboardEntry(self, test):

--- a/gradescope_utils/autograder_utils/json_test_runner.py
+++ b/gradescope_utils/autograder_utils/json_test_runner.py
@@ -75,6 +75,7 @@ class JSONTestResult(result.TestResult):
         hide_errors_message = self.getHideErrors(test)
         score = self.getScore(test)
         output = self.getOutput() or ""
+
         if err:
             if hide_errors_message:
                 output += hide_errors_message
@@ -219,6 +220,16 @@ class JSONTestRunner(object):
         if self.post_processor is not None:
             self.post_processor(self.json_data)
 
+
+        while i < len(self.json_data["tests"]):
+            if self.json_data["tests"][i]["name"] == self.json_data["tests"][i+1]["name"]:
+                self.json_data["tests"][i]["output"] += self.json_data["tests"][i+1]["output"]
+                del self.json_data["tests"][i+1]
+            else:
+                i += 1
+                if i >= len(self.json_data["tests"]):
+                    break
+        
         json.dump(self.json_data, self.stream, indent=4)
         self.stream.write('\n')
         return result

--- a/gradescope_utils/autograder_utils/json_test_runner.py
+++ b/gradescope_utils/autograder_utils/json_test_runner.py
@@ -164,8 +164,7 @@ class JSONTestRunner(object):
     def __init__(self, stream=sys.stdout, descriptions=True, verbosity=1,
                  failfast=False, buffer=True, visibility=None,
                  stdout_visibility=None, post_processor=None,
-                 failure_prefix="Test Failed: ",
-                 merge_subtests=False):
+                 failure_prefix="Test Failed: "):
         """
         Set buffer to True to include test output in JSON
 
@@ -183,7 +182,6 @@ class JSONTestRunner(object):
         self.failfast = failfast
         self.buffer = buffer
         self.post_processor = post_processor
-        self.merge_subtests = merge_subtests
         self.json_data = {
             "tests": [],
             "leaderboard": [],
@@ -228,17 +226,17 @@ class JSONTestRunner(object):
         if self.post_processor is not None:
             self.post_processor(self.json_data)
 
-        if self.merge_subtests:
-            if len(self.json_data["tests"]) > 1:
-                i = 0
-                while i < len(self.json_data["tests"]):
-                    if self.json_data["tests"][i]["name"] == self.json_data["tests"][i+1]["name"]:
-                        self.json_data["tests"][i]["output"] += self.json_data["tests"][i+1]["output"]
-                        del self.json_data["tests"][i+1]
-                    else:
-                        i += 1
-                        if i + 1 >= len(self.json_data["tests"]):
-                            break
+        if len(self.json_data["tests"]) > 1:
+            i = 0
+            while i < len(self.json_data["tests"]):
+                if (self.json_data["tests"][i]["name"] == self.json_data["tests"][i+1]["name"]
+                    and self.json_data["tests"][i]["merge_subtests"] == True):
+                    self.json_data["tests"][i]["output"] += self.json_data["tests"][i+1]["output"]
+                    del self.json_data["tests"][i+1]
+                else:
+                    i += 1
+                    if i + 1 >= len(self.json_data["tests"]):
+                        break
             
         json.dump(self.json_data, self.stream, indent=4)
         self.stream.write('\n')

--- a/gradescope_utils/autograder_utils/json_test_runner.py
+++ b/gradescope_utils/autograder_utils/json_test_runner.py
@@ -225,12 +225,9 @@ class JSONTestRunner(object):
         if self.post_processor is not None:
             self.post_processor(self.json_data)
 
-
-        json.dump(self.json_data, self.stream, indent=4)
-        self.stream.write('\n')
-        print(self.json_data)
-
-        if len(self.json_data["tests"]) > 1:
+        if ("merge_subtests" in self.json_data["tests"] 
+            and len(self.json_data["tests"]) > 1):
+            
             i = 0
             while i < len(self.json_data["tests"]):
                 if (self.json_data["tests"][i]["name"] == self.json_data["tests"][i+1]["name"]
@@ -242,5 +239,7 @@ class JSONTestRunner(object):
                     if i + 1 >= len(self.json_data["tests"]):
                         break
             
+        json.dump(self.json_data, self.stream, indent=4)
+        self.stream.write('\n')
 
         return result

--- a/gradescope_utils/autograder_utils/json_test_runner.py
+++ b/gradescope_utils/autograder_utils/json_test_runner.py
@@ -142,8 +142,7 @@ class JSONTestResult(result.TestResult):
 
     def addSubTest(self, test, subtest, outcome):
         if outcome == None:
-            super(JSONTestResult, self).addSuccess(subtest)
-        
+            pass
         else:
             super(JSONTestResult, self).addFailure(subtest, outcome)
             self._mirrorOutput = False

--- a/gradescope_utils/autograder_utils/json_test_runner.py
+++ b/gradescope_utils/autograder_utils/json_test_runner.py
@@ -229,7 +229,8 @@ class JSONTestRunner(object):
 
         json.dump(self.json_data, self.stream, indent=4)
         self.stream.write('\n')
-        
+        print(self.json_data)
+
         if len(self.json_data["tests"]) > 1:
             i = 0
             while i < len(self.json_data["tests"]):

--- a/gradescope_utils/autograder_utils/json_test_runner.py
+++ b/gradescope_utils/autograder_utils/json_test_runner.py
@@ -227,8 +227,6 @@ class JSONTestRunner(object):
                 if self.json_data["tests"][i]["name"] == self.json_data["tests"][i+1]["name"]:
                     self.json_data["tests"][i]["output"] += self.json_data["tests"][i+1]["output"]
                     del self.json_data["tests"][i+1]
-                    if i + 1 >= len(self.json_data["tests"]):
-                        break
                 else:
                     i += 1
                     if i + 1 >= len(self.json_data["tests"]):

--- a/gradescope_utils/autograder_utils/json_test_runner.py
+++ b/gradescope_utils/autograder_utils/json_test_runner.py
@@ -144,9 +144,9 @@ class JSONTestResult(result.TestResult):
         if outcome == None:
             pass
         else:
-            super(JSONTestResult, self).addFailure(test, outcome)
+            super(JSONTestResult, self).addFailure(subtest, outcome)
             self._mirrorOutput = False
-            self.processResult(subtest, outcome)
+            self.processResult(test, outcome)
 
 
 class JSONTestRunner(object):

--- a/gradescope_utils/autograder_utils/json_test_runner.py
+++ b/gradescope_utils/autograder_utils/json_test_runner.py
@@ -220,16 +220,18 @@ class JSONTestRunner(object):
         if self.post_processor is not None:
             self.post_processor(self.json_data)
 
-        i = 0
-        while i < len(self.json_data["tests"]):
-            if self.json_data["tests"][i]["name"] == self.json_data["tests"][i+1]["name"]:
-                self.json_data["tests"][i]["output"] += self.json_data["tests"][i+1]["output"]
-                del self.json_data["tests"][i+1]
-            else:
-                i += 1
-                if i + 1 >= len(self.json_data["tests"]):
-                    break
         
+        if len(self.json_data["tests"]) > 1:
+            i = 0
+            while i < len(self.json_data["tests"]):
+                if self.json_data["tests"][i]["name"] == self.json_data["tests"][i+1]["name"]:
+                    self.json_data["tests"][i]["output"] += self.json_data["tests"][i+1]["output"]
+                    del self.json_data["tests"][i+1]
+                else:
+                    i += 1
+                    if i + 1 >= len(self.json_data["tests"]):
+                        break
+            
         json.dump(self.json_data, self.stream, indent=4)
         self.stream.write('\n')
         return result

--- a/gradescope_utils/autograder_utils/json_test_runner.py
+++ b/gradescope_utils/autograder_utils/json_test_runner.py
@@ -225,19 +225,22 @@ class JSONTestRunner(object):
         if self.post_processor is not None:
             self.post_processor(self.json_data)
 
-        if ("merge_subtests" in self.json_data["tests"] 
-            and len(self.json_data["tests"]) > 1):
-            
-            i = 0
-            while i < len(self.json_data["tests"]):
-                if (self.json_data["tests"][i]["name"] == self.json_data["tests"][i+1]["name"]
-                    and self.json_data["tests"][i]["merge_subtests"] == 'True'):
-                    self.json_data["tests"][i]["output"] += self.json_data["tests"][i+1]["output"]
-                    del self.json_data["tests"][i+1]
-                else:
-                    i += 1
-                    if i + 1 >= len(self.json_data["tests"]):
-                        break
+        
+        try:
+            if len(self.json_data["tests"]) > 1:
+
+                i = 0
+                while i < len(self.json_data["tests"]):
+                    if (self.json_data["tests"][i]["name"] == self.json_data["tests"][i+1]["name"]
+                        and self.json_data["tests"][i]["merge_subtests"] == 'True'):
+                        self.json_data["tests"][i]["output"] += self.json_data["tests"][i+1]["output"]
+                        del self.json_data["tests"][i+1]
+                    else:
+                        i += 1
+                        if i + 1 >= len(self.json_data["tests"]):
+                            break
+        except KeyError:
+            pass
             
         json.dump(self.json_data, self.stream, indent=4)
         self.stream.write('\n')

--- a/gradescope_utils/autograder_utils/json_test_runner.py
+++ b/gradescope_utils/autograder_utils/json_test_runner.py
@@ -220,7 +220,7 @@ class JSONTestRunner(object):
         if self.post_processor is not None:
             self.post_processor(self.json_data)
 
-
+        i = 0
         while i < len(self.json_data["tests"]):
             if self.json_data["tests"][i]["name"] == self.json_data["tests"][i+1]["name"]:
                 self.json_data["tests"][i]["output"] += self.json_data["tests"][i+1]["output"]

--- a/gradescope_utils/autograder_utils/json_test_runner.py
+++ b/gradescope_utils/autograder_utils/json_test_runner.py
@@ -165,7 +165,7 @@ class JSONTestRunner(object):
                  failfast=False, buffer=True, visibility=None,
                  stdout_visibility=None, post_processor=None,
                  failure_prefix="Test Failed: ",
-                 merge_subtests=True):
+                 merge_subtests=False):
         """
         Set buffer to True to include test output in JSON
 

--- a/gradescope_utils/autograder_utils/json_test_runner.py
+++ b/gradescope_utils/autograder_utils/json_test_runner.py
@@ -227,7 +227,7 @@ class JSONTestRunner(object):
                 del self.json_data["tests"][i+1]
             else:
                 i += 1
-                if i >= len(self.json_data["tests"]):
+                if i + 1 >= len(self.json_data["tests"]):
                     break
         
         json.dump(self.json_data, self.stream, indent=4)

--- a/gradescope_utils/autograder_utils/json_test_runner.py
+++ b/gradescope_utils/autograder_utils/json_test_runner.py
@@ -140,6 +140,16 @@ class JSONTestResult(result.TestResult):
         self._mirrorOutput = False
         self.processResult(test, err)
 
+    def addSubTest(self, test, subtest, outcome):
+        if outcome == None:
+            super(JSONTestResult, self).addSuccess(subtest)
+        
+        else:
+            super(JSONTestResult, self).addFailure(subtest, outcome)
+            self._mirrorOutput = False
+        
+        self.processResult(subtest, outcome)
+
 
 class JSONTestRunner(object):
     """A test runner class that displays results in JSON form.

--- a/gradescope_utils/autograder_utils/json_test_runner.py
+++ b/gradescope_utils/autograder_utils/json_test_runner.py
@@ -146,7 +146,7 @@ class JSONTestResult(result.TestResult):
         else:
             super(JSONTestResult, self).addFailure(test, outcome)
             self._mirrorOutput = False
-            self.processResult(test, outcome)
+            self.processResult(subtest, outcome)
 
 
 class JSONTestRunner(object):

--- a/gradescope_utils/autograder_utils/json_test_runner.py
+++ b/gradescope_utils/autograder_utils/json_test_runner.py
@@ -146,8 +146,7 @@ class JSONTestResult(result.TestResult):
         else:
             super(JSONTestResult, self).addFailure(subtest, outcome)
             self._mirrorOutput = False
-        
-        self.processResult(subtest, outcome)
+            self.processResult(subtest, outcome)
 
 
 class JSONTestRunner(object):

--- a/gradescope_utils/autograder_utils/json_test_runner.py
+++ b/gradescope_utils/autograder_utils/json_test_runner.py
@@ -79,7 +79,6 @@ class JSONTestResult(result.TestResult):
         score = self.getScore(test)
         output = self.getOutput() or ""
         merge_subtests = self.getMergeSubtests(test)
-
         if err:
             if hide_errors_message:
                 output += hide_errors_message
@@ -114,7 +113,8 @@ class JSONTestResult(result.TestResult):
             result["visibility"] = visibility
         if number:
             result["number"] = number
-        result["merge_subtests"] = merge_subtests
+        if merge_subtests:
+            result["merge_subtests"] = merge_subtests
         return result
 
     def buildLeaderboardEntry(self, test):
@@ -234,7 +234,7 @@ class JSONTestRunner(object):
             i = 0
             while i < len(self.json_data["tests"]):
                 if (self.json_data["tests"][i]["name"] == self.json_data["tests"][i+1]["name"]
-                    and self.json_data["tests"][i]["merge_subtests"] == True):
+                    and self.json_data["tests"][i]["merge_subtests"] == 'True'):
                     self.json_data["tests"][i]["output"] += self.json_data["tests"][i+1]["output"]
                     del self.json_data["tests"][i+1]
                 else:

--- a/gradescope_utils/autograder_utils/json_test_runner.py
+++ b/gradescope_utils/autograder_utils/json_test_runner.py
@@ -227,6 +227,8 @@ class JSONTestRunner(object):
                 if self.json_data["tests"][i]["name"] == self.json_data["tests"][i+1]["name"]:
                     self.json_data["tests"][i]["output"] += self.json_data["tests"][i+1]["output"]
                     del self.json_data["tests"][i+1]
+                    if i + 1 >= len(self.json_data["tests"]):
+                        break
                 else:
                     i += 1
                     if i + 1 >= len(self.json_data["tests"]):


### PR DESCRIPTION
**Apologies - I meant to submit this request in my own repository.**

Subtest output can be displayed on Gradescope as a single test or multiple tests by using the @merge_subtests decorator. Displaying each subtest as its own test case removes the score from the test title in Gradescope to avoid scoring confusion for the user. 